### PR TITLE
Implement Phase 2 translation pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and add your OpenAI API key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # satochizai
 
 See MVP_PLAN.md for the development plan.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and set your `OPENAI_API_KEY`.
+2. Install dependencies:
+   ```bash
+   pip install -r diverse_perspective_mvp/requirements.txt
+   ```
+3. Run the prototype Streamlit app:
+   ```bash
+   streamlit run diverse_perspective_mvp/app.py
+   ```

--- a/diverse_perspective_mvp/app.py
+++ b/diverse_perspective_mvp/app.py
@@ -10,6 +10,8 @@ if st.button("分析開始"):
         st.warning("テキストを入力してください")
     else:
         st.write("多様な言語経路を選択中...")
-        path = core_logic.select_diverse_languages('en')
-        st.write("多段階翻訳と意味分析を実行中...")
-        st.write(path)
+        translations = core_logic.translate_via_diverse_path(source_text, 'en')
+        st.write("翻訳結果:")
+        for lang, text in translations:
+            st.subheader(lang)
+            st.write(text)

--- a/diverse_perspective_mvp/core_logic.py
+++ b/diverse_perspective_mvp/core_logic.py
@@ -3,6 +3,7 @@ from gdelt import GDelt
 from itertools import permutations
 
 from .data_handler import load_hofstede_scores, load_wals_features
+from .translator import run_translation_chain
 
 
 def calculate_cds(country1_code: str, country2_code: str) -> float:
@@ -74,3 +75,12 @@ def select_diverse_languages(source_language: str, num_pivots: int = 3):
         candidate_langs.remove(best_lang)
         current = best_lang
     return best_path
+
+
+def translate_via_diverse_path(
+    source_text: str, source_language: str = "en", num_pivots: int = 3
+) -> list[tuple[str, str]]:
+    """Select a diverse language path and run sequential translations."""
+
+    path = select_diverse_languages(source_language, num_pivots)
+    return run_translation_chain(source_text, path)

--- a/diverse_perspective_mvp/requirements.txt
+++ b/diverse_perspective_mvp/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn
 plotly
 streamlit
 openai
+python-dotenv

--- a/diverse_perspective_mvp/translator.py
+++ b/diverse_perspective_mvp/translator.py
@@ -1,0 +1,30 @@
+import os
+from typing import List, Tuple
+
+import openai
+from dotenv import load_dotenv
+
+# Load API key from .env if present
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def translate_text(text: str, src: str, tgt: str) -> str:
+    """Translate text from src language to tgt language via ChatCompletion."""
+    prompt = f"Translate the following text from {src} to {tgt}:\n{text}"
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0
+    )
+    return response.choices[0].message.content.strip()
+
+
+def run_translation_chain(source_text: str, language_path: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+    """Run sequential translations along the given language path."""
+    text = source_text
+    results = []
+    for src, tgt in language_path:
+        text = translate_text(text, src, tgt)
+        results.append((tgt, text))
+    return results


### PR DESCRIPTION
## Summary
- integrate translator into core logic
- update Streamlit app to run translation chain
- document how to launch the app

## Testing
- `pip install openai python-dotenv`
- `python -m compileall diverse_perspective_mvp`
- `python - <<'EOF'
import diverse_perspective_mvp.translator as t
print('translate_text' in dir(t), 'run_translation_chain' in dir(t))
EOF`
- `python - <<'EOF'
import types, sys
sys.modules['gdelt'] = types.SimpleNamespace(GDelt=object)
import diverse_perspective_mvp.core_logic as c
print('translate_via_diverse_path' in dir(c))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684fc70337ec83338f1f0ce3d8bbf370